### PR TITLE
Added g:Vimphpcs_ExtraArgs global.

### DIFF
--- a/plugin/phpcs.vim
+++ b/plugin/phpcs.vim
@@ -46,7 +46,7 @@ if !exists('Vimphpcs_Standard')
 endif
 
 function! s:CodeSniff(extraarg)
-    let l:extraarg       = a:extraarg
+    let l:extraarg       = a:extraarg.' '.g:Vimphpcs_ExtraArgs
 	let l:filename       = @%
     let l:phpcs_cmd      = g:Vimphpcs_Phpcscmd
     let l:phpcs_standard = g:Vimphpcs_Standard


### PR DESCRIPTION
Added specifically to support the use case with Drupal code validator
DrupalCS, added ExtraArgs so that --extensions flag can be specified
easily in vimrc when editing Drupal module and theme code. Probably has
other uses as well.

I'm a n00b to writing vimscript, so apologies if there are any gross errors in this.

Thanks for this module.  It's making compliance with Drupal's strict standards just a little less painful, which is very welcome.
